### PR TITLE
Added support for IE<=8

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,3 +1,123 @@
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Polyfill
+var _map = [].map || function(callback, thisArg) {
+
+  var T, A, k;
+
+  if (this == null) {
+    throw new TypeError(' this is null or not defined');
+  }
+
+  // 1. Let O be the result of calling ToObject passing the |this|
+  //    value as the argument.
+  var O = Object(this);
+
+  // 2. Let lenValue be the result of calling the Get internal
+  //    method of O with the argument "length".
+  // 3. Let len be ToUint32(lenValue).
+  var len = O.length >>> 0;
+
+  // 4. If IsCallable(callback) is false, throw a TypeError exception.
+  // See: http://es5.github.com/#x9.11
+  if (typeof callback !== 'function') {
+    throw new TypeError(callback + ' is not a function');
+  }
+
+  // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
+  if (arguments.length > 1) {
+    T = thisArg;
+  }
+
+  // 6. Let A be a new array created as if by the expression new Array(len)
+  //    where Array is the standard built-in constructor with that name and
+  //    len is the value of len.
+  A = new Array(len);
+
+  // 7. Let k be 0
+  k = 0;
+
+  // 8. Repeat, while k < len
+  while (k < len) {
+
+    var kValue, mappedValue;
+
+    // a. Let Pk be ToString(k).
+    //   This is implicit for LHS operands of the in operator
+    // b. Let kPresent be the result of calling the HasProperty internal
+    //    method of O with argument Pk.
+    //   This step can be combined with c
+    // c. If kPresent is true, then
+    if (k in O) {
+
+      // i. Let kValue be the result of calling the Get internal
+      //    method of O with argument Pk.
+      kValue = O[k];
+
+      // ii. Let mappedValue be the result of calling the Call internal
+      //     method of callback with T as the this value and argument
+      //     list containing kValue, k, and O.
+      mappedValue = callback.call(T, kValue, k, O);
+
+      // iii. Call the DefineOwnProperty internal method of A with arguments
+      // Pk, Property Descriptor
+      // { Value: mappedValue,
+      //   Writable: true,
+      //   Enumerable: true,
+      //   Configurable: true },
+      // and false.
+
+      // In browsers that support Object.defineProperty, use the following:
+      // Object.defineProperty(A, k, {
+      //   value: mappedValue,
+      //   writable: true,
+      //   enumerable: true,
+      //   configurable: true
+      // });
+
+      // For best browser support, use the following:
+      A[k] = mappedValue;
+    }
+    // d. Increase k by 1.
+    k++;
+  }
+
+  // 9. return A
+  return A;
+};
+
+// see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Polyfill
+var _filter = [].filter || function(fun/*, thisArg*/) {
+  'use strict';
+
+  if (this === void 0 || this === null) {
+    throw new TypeError();
+  }
+
+  var t = Object(this);
+  var len = t.length >>> 0;
+  if (typeof fun !== 'function') {
+    throw new TypeError();
+  }
+
+  var res = [];
+  var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+  for (var i = 0; i < len; i++) {
+    if (i in t) {
+      var val = t[i];
+
+      // NOTE: Technically this should Object.defineProperty at
+      //       the next index, as push can be affected by
+      //       properties on Object.prototype and Array.prototype.
+      //       But that method's new, and collisions should be
+      //       rare, so use the more-compatible alternative.
+      if (fun.call(thisArg, val, i, t)) {
+        res.push(val);
+      }
+    }
+  }
+
+  return res;
+};
+
 var browsers = [
   [ 'chrome', /Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
   [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$)/ ],
@@ -12,7 +132,16 @@ var browsers = [
   [ 'safari', /Safari\/([0-9\._]+)/ ]
 ];
 
-var match = browsers.map(match).filter(isMatch)[0];
+function _match(pair) {
+  return pair.concat(pair[1].exec(navigator.userAgent));
+}
+
+function _isMatch(pair) {
+  return !!pair[2];
+}
+
+var mappedMatch = _map.apply(browsers, [_match]);
+var match = _filter.apply(mappedMatch, [_isMatch])[0];
 var parts = match && match[3].split(/[._]/).slice(0,3);
 
 while (parts && parts.length < 3) {
@@ -22,11 +151,3 @@ while (parts && parts.length < 3) {
 // set the name and version
 exports.name = match && match[0];
 exports.version = parts && parts.join('.');
-
-function match(pair) {
-  return pair.concat(pair[1].exec(navigator.userAgent));
-}
-
-function isMatch(pair) {
-  return !!pair[2];
-}


### PR DESCRIPTION
Added polyfill (mozilla implementation) of [].map and [].filter.
Some (not)browser like IE8 does not support those functions.
Also done a little refactoring on function names, a function and a variable with the same name is not strictly safe.