### PR TITLE
Fix Opera detect

### DIFF
--- a/lib/detectBrowser.js
+++ b/lib/detectBrowser.js
@@ -1,9 +1,9 @@
 module.exports = function detectBrowser(userAgentString) {
   var browsers = [
     [ 'edge', /Edge\/([0-9\._]+)/ ],
+    [ 'opera', /OPR\/([0-9\.]+)(?:\s|$)/ ],
     [ 'chrome', /Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
     [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$)/ ],
-    [ 'opera', /Opera\/([0-9\.]+)(?:\s|$)/ ],
     [ 'ie', /Trident\/7\.0.*rv\:([0-9\.]+)\).*Gecko$/ ],
     [ 'ie', /MSIE\s([0-9\.]+);.*Trident\/[4-7].0/ ],
     [ 'ie', /MSIE\s(7\.0)/ ],

--- a/lib/detectBrowser.js
+++ b/lib/detectBrowser.js
@@ -1,7 +1,7 @@
 module.exports = function detectBrowser(userAgentString) {
   var browsers = [
     [ 'edge', /Edge\/([0-9\._]+)/ ],
-    [ 'opera', /OPR\/([0-9\.]+)(?:\s|$)/ ],
+    [ 'opera', /(OPR|Opera)\/([0-9\.]+)(?:\s|$)/ ],
     [ 'chrome', /Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
     [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$)/ ],
     [ 'ie', /Trident\/7\.0.*rv\:([0-9\.]+)\).*Gecko$/ ],


### PR DESCRIPTION
Since Opera 15 (released in 2013) the string "OPR" is used instead of "Opera"
https://dev.opera.com/blog/opera-user-agent-strings-opera-15-and-beyond/

I moved Opera before Chrome in the browsers array because Opera use Webkit, and there is the "Chrome" key in the user agent string. The Opera user agent string on my Mac:
`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36 OPR/38.0.2220.31`