### PR TITLE
account for updated opera UA strings

### DIFF
--- a/lib/detectBrowser.js
+++ b/lib/detectBrowser.js
@@ -1,9 +1,10 @@
 module.exports = function detectBrowser(userAgentString) {
   var browsers = [
     [ 'edge', /Edge\/([0-9\._]+)/ ],
-    [ 'chrome', /Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
+    [ 'chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
     [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$)/ ],
     [ 'opera', /Opera\/([0-9\.]+)(?:\s|$)/ ],
+    [ 'opera', /OPR\/([0-9\.]+)(:?\s|$)$/ ],
     [ 'ie', /Trident\/7\.0.*rv\:([0-9\.]+)\).*Gecko$/ ],
     [ 'ie', /MSIE\s([0-9\.]+);.*Trident\/[4-7].0/ ],
     [ 'ie', /MSIE\s(7\.0)/ ],

--- a/test/logic.js
+++ b/test/logic.js
@@ -77,6 +77,11 @@ test('detects Opera', function(t) {
     { name: 'opera', version: '9.25.0' }
   );
 
+  assertAgentString(t,
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36 OPR/38.0.2220.31',
+    { name: 'opera', version: '38.0.2220' }
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
fixes #15

more recent versions of opera have adopted a UA string that closer
resembles that of chrome, and is currently falsely detected as such.