### PR TITLE
Fix grammatical error in test helper

### DIFF
--- a/test/logic.js
+++ b/test/logic.js
@@ -1,8 +1,8 @@
 var test = require('tape');
 var detectBrowser = require('../lib/detectBrowser');
 
-function assertAgentString(t, agentString, extectedResult) {
-  t.deepEqual(detectBrowser(agentString), extectedResult);
+function assertAgentString(t, agentString, expectedResult) {
+  t.deepEqual(detectBrowser(agentString), expectedResult);
 }
 
 test('detects Chrome', function(t) {


### PR DESCRIPTION
I believe the intent was `expectedResult` not `extectedResult`