### PR TITLE
Added null navigator handling

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,3 +1,9 @@
 var detectBrowser = require('./lib/detectBrowser');
 
-module.exports = detectBrowser(navigator.userAgent);
+var agent;
+
+if (typeof navigator === 'undefined' || !navigator) {
+  agent = navigator.userAgent;
+}
+
+module.exports = detectBrowser(agent);

--- a/browser.js
+++ b/browser.js
@@ -2,7 +2,7 @@ var detectBrowser = require('./lib/detectBrowser');
 
 var agent;
 
-if (typeof navigator === 'undefined' || !navigator) {
+if (typeof navigator !== 'undefined' || navigator) {
   agent = navigator.userAgent;
 }
 

--- a/browser.js
+++ b/browser.js
@@ -2,7 +2,7 @@ var detectBrowser = require('./lib/detectBrowser');
 
 var agent;
 
-if (typeof navigator !== 'undefined' || navigator) {
+if (typeof navigator !== 'undefined' && navigator) {
   agent = navigator.userAgent;
 }
 

--- a/lib/detectBrowser.js
+++ b/lib/detectBrowser.js
@@ -1,4 +1,6 @@
 module.exports = function detectBrowser(userAgentString) {
+  if (!userAgentString) return null;
+
   var browsers = [
     [ 'edge', /Edge\/([0-9\._]+)/ ],
     [ 'yandexbrowser', /YaBrowser\/([0-9\._]+)/ ],

--- a/test/logic.js
+++ b/test/logic.js
@@ -143,3 +143,12 @@ test('detects Yandex Browser', function(t) {
 
     t.end();
 });
+
+test('handles no browser', function(t) {
+    assertAgentString(t,
+        null,
+        null
+    );
+
+    t.end();
+});


### PR DESCRIPTION
Added error handling for when `navigator` does not exist. Useful for isomorphic rendering of apps when the `navigator` does not exist server side.