### PR TITLE
report that a browser is unknown (empty user agent string)

### DIFF
--- a/lib/detectBrowser.js
+++ b/lib/detectBrowser.js
@@ -16,19 +16,25 @@ module.exports = function detectBrowser(userAgentString) {
     [ 'safari', /Version\/([0-9\._]+).*Safari/ ]
   ];
 
-  return browsers.map(function (rule) {
-      if (rule[1].test(userAgentString)) {
-          var match = rule[1].exec(userAgentString);
-          var version = match && match[1].split(/[._]/).slice(0,3);
-
-          if (version && version.length < 3) {
-              Array.prototype.push.apply(version, (version.length == 1) ? [0, 0] : [0]);
-          }
-
-          return {
-              name: rule[0],
-              version: version.join('.')
-          };
-      }
+  var detectedBrowser = browsers.map(function(rule) {
+    return checkBrowserMatch(userAgentString, rule);
   }).filter(Boolean).shift();
+
+  return detectedBrowser || { name: 'unknown', version: null };
 };
+
+function checkBrowserMatch(userAgentString, rule) {
+  if (rule[1].test(userAgentString)) {
+    var match = rule[1].exec(userAgentString);
+    var version = match && match[1].split(/[._]/).slice(0,3);
+
+    if (version && version.length < 3) {
+      Array.prototype.push.apply(version, (version.length == 1) ? [0, 0] : [0]);
+    }
+
+    return {
+      name: rule[0],
+      version: version.join('.')
+    };
+  }
+}

--- a/test/logic.js
+++ b/test/logic.js
@@ -5,6 +5,15 @@ function assertAgentString(t, agentString, expectedResult) {
   t.deepEqual(detectBrowser(agentString), expectedResult);
 }
 
+test('unknown navigator string returns unknown', function(t) {
+  assertAgentString(t,
+    'Foobar/7.0 Super browser EX plus alpha',
+    { name: 'unknown', version: null }
+  );
+
+  t.end();
+});
+
 test('detects Chrome', function(t) {
   assertAgentString(t,
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36',


### PR DESCRIPTION
This addresses issue #30.  As mentioned in that issue thread implementing this functionality would mean a `2.0.0` release in the event that folks are relying on the `undefined` result in the current behaviour.

@tomekwi @snuggs Can you take a look at this and see what you think?  I do think this change means that `detect-browser` probably has less surprising behaviour even if the result is the same.  The only question is whether the `undefined` result is actually preferred?  The downside is that you start to rely on string comparisons for checking if a browser is unknown.  The new implementation is definitely more robust for cases like usage in switch statements though...

It's possible that it might be and that a documentation update on the README might be the best solution.

/cc @mikeebee