### PR TITLE
issue #35: modify IE11 regex to match another valid UA string

### DIFF
--- a/lib/detectBrowser.js
+++ b/lib/detectBrowser.js
@@ -9,7 +9,7 @@ module.exports = function detectBrowser(userAgentString) {
     [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$)/ ],
     [ 'opera', /Opera\/([0-9\.]+)(?:\s|$)/ ],
     [ 'opera', /OPR\/([0-9\.]+)(:?\s|$)$/ ],
-    [ 'ie', /Trident\/7\.0.*rv\:([0-9\.]+)\).*Gecko$/ ],
+    [ 'ie', /Trident\/7\.0.*rv\:([0-9\.]+).*\).*Gecko$/ ],
     [ 'ie', /MSIE\s([0-9\.]+);.*Trident\/[4-7].0/ ],
     [ 'ie', /MSIE\s(7\.0)/ ],
     [ 'bb10', /BB10;\sTouch.*Version\/([0-9\.]+)/ ],

--- a/test/logic.js
+++ b/test/logic.js
@@ -63,6 +63,11 @@ test('detects IE', function(t) {
   );
 
   assertAgentString(t,
+    'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0; MSN 11.61; MSNbMSNI; MSNmen-us; MSNcOTH) like Gecko',
+    { name: 'ie', version: '11.0.0' }
+  );
+
+  assertAgentString(t,
     'Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0',
     { name: 'ie', version: '10.6.0' }
   );


### PR DESCRIPTION
Described here:
https://github.com/DamonOehlman/detect-browser/issues/35

Discovered this UA string in our logs:
`Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0; MSN 11.61; MSNbMSNI; MSNmen-us; MSNcOTH) like Gecko` and it's IE11 per https://browscap.org/ua-lookup
