### PR TITLE
Add FxiOS to list of browsers

### DIFF
--- a/lib/detectBrowser.js
+++ b/lib/detectBrowser.js
@@ -7,6 +7,7 @@ module.exports = function detectBrowser(userAgentString) {
     [ 'chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
     [ 'crios', /CriOS\/([0-9\.]+)(:?\s|$)/ ],
     [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$)/ ],
+    [ 'fxios', /FxiOS\/([0-9\.]+)/ ],
     [ 'opera', /Opera\/([0-9\.]+)(?:\s|$)/ ],
     [ 'opera', /OPR\/([0-9\.]+)(:?\s|$)$/ ],
     [ 'ie', /Trident\/7\.0.*rv\:([0-9\.]+).*\).*Gecko$/ ],

--- a/test/logic.js
+++ b/test/logic.js
@@ -42,6 +42,20 @@ test('detects Firefox', function(t) {
   t.end();
 });
 
+test('detects Firefox for iOS', function(t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
+    { name: 'fxios', version: '1.0.0' }
+  );
+
+  assertAgentString(t,
+    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
+    { name: 'firefox', version: '40.1.0' }
+  );
+
+  t.end();
+});
+
 test('detects Edge', function(t) {
   assertAgentString(t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',

--- a/test/logic.js
+++ b/test/logic.js
@@ -49,8 +49,8 @@ test('detects Firefox for iOS', function(t) {
   );
 
   assertAgentString(t,
-    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
-    { name: 'firefox', version: '40.1.0' }
+    'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/3.2 Mobile/12F69 Safari/600.1.4',
+    { name: 'fxios', version: '3.2.0' }
   );
 
   t.end();


### PR DESCRIPTION
Firefox on iOS has a different [UserAgent string](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox#Firefox_for_iOS).
Since this was undefined, the `detect-browser` was returning undefined.