### PR TITLE
Facebook/Instagram in-app browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Creating an acceptable implementation requires two things:
    your new browser correctly.  Examples of this can be found in the 
    `test/logic.js` file.
 
-2. Write the actual regex to the `lib/detectBrowser.js` file. In most cases adding
+2. Write the actual regex to the `index.js` file. In most cases adding
    the regex to the list of existing regexes will be suitable (if usage of `detect-brower`
    returns `undefined` for instance), but in some cases you might have to add it before
    an existing regex.  This would be true for a case where you have a browser that

--- a/index.js
+++ b/index.js
@@ -121,7 +121,8 @@ function getBrowserRules() {
     [ 'bb10', /BB10;\sTouch.*Version\/([0-9\.]+)/ ],
     [ 'android', /Android\s([0-9\.]+)/ ],
     [ 'ios', /Version\/([0-9\._]+).*Mobile.*Safari.*/ ],
-    [ 'safari', /Version\/([0-9\._]+).*Safari/ ]
+    [ 'safari', /Version\/([0-9\._]+).*Safari/ ],
+    ['facebook', /FBAV\/([0-9\.]+)/],
   ]);
 }
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,8 @@ function getBrowserRules() {
     [ 'android', /Android\s([0-9\.]+)/ ],
     [ 'ios', /Version\/([0-9\._]+).*Mobile.*Safari.*/ ],
     [ 'safari', /Version\/([0-9\._]+).*Safari/ ],
-    ['facebook', /FBAV\/([0-9\.]+)/],
+    [ 'facebook', /FBAV\/([0-9\.]+)/],
+    [ 'instagram', /Instagram\ ([0-9\.]+)/]
   ]);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "detect-browser",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -13,7 +14,10 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -25,13 +29,20 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "buffer-from": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
       "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-array-buffer-x": "1.2.1"
+      }
     },
     "cog": {
       "version": "1.1.0",
@@ -55,7 +66,10 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -67,7 +81,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
     },
     "defined": {
       "version": "1.0.0",
@@ -79,31 +97,51 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
     },
     "emu": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/emu/-/emu-1.0.0.tgz",
       "integrity": "sha1-7xcpRNyIkpW9Sv5PNSmMPsWObt0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "literalizer": "0.4.0-a"
+      }
     },
     "es-abstract": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "for-each": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -133,25 +171,55 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gendocs/-/gendocs-2.0.0.tgz",
       "integrity": "sha1-6PNbvsVvXpIgQjDj94cBxyzWm1w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "cog": "1.1.0",
+        "emu": "1.0.0",
+        "formatter": "0.4.1",
+        "getit": "1.1.0",
+        "minimatch": "3.0.4",
+        "nopt": "3.0.6",
+        "out": "1.0.0",
+        "pull-group": "1.0.1",
+        "pull-stream": "2.28.4",
+        "sourcecat": "1.1.0"
+      }
     },
     "getit": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/getit/-/getit-1.1.0.tgz",
       "integrity": "sha1-gZ+MtMSVMDWKWh2ewCJzrh5Zk6Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "hyperquest": "2.1.2",
+        "mkdirp": "0.5.1",
+        "urlish": "1.0.1"
+      }
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-symbol-support-x": {
       "version": "1.2.0",
@@ -163,19 +231,31 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.2.0.tgz",
       "integrity": "sha1-xTbcTbvr4b6dKPYk/TIPeTEp/VM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "1.2.0"
+      }
     },
     "hyperquest": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.2.tgz",
       "integrity": "sha1-ldv2/MdMdJuuVcw5MhM13datwVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-from": "0.1.1",
+        "duplexer2": "0.0.2",
+        "through2": "0.6.5"
+      }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -187,7 +267,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.2.1.tgz",
       "integrity": "sha1-V5GAaIthKzaRcA1smrM11v1GlVw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "1.2.0",
+        "is-object-like-x": "1.2.0",
+        "to-string-tag-x": "1.2.0"
+      }
     },
     "is-callable": {
       "version": "1.1.3",
@@ -211,13 +296,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-1.2.0.tgz",
       "integrity": "sha1-HIOYmfB70j38aV5PBlUQe+hSdi0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "1.2.0",
+        "is-primitive": "2.0.0",
+        "to-string-tag-x": "1.2.0"
+      }
     },
     "is-object-like-x": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.2.0.tgz",
       "integrity": "sha1-tZKdjxKrktrunS91S4MYRLzAjCE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-function-x": "1.2.0",
+        "is-primitive": "2.0.0"
+      }
     },
     "is-primitive": {
       "version": "2.0.0",
@@ -229,7 +323,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -265,7 +362,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -278,6 +378,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -297,7 +400,10 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.0"
+      }
     },
     "object-inspect": {
       "version": "1.2.2",
@@ -315,7 +421,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "out": {
       "version": "1.0.0",
@@ -345,13 +454,22 @@
       "version": "2.28.4",
       "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
       "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pull-core": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "resolve": {
       "version": "1.1.7",
@@ -363,7 +481,10 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "semver": {
       "version": "5.3.0",
@@ -375,7 +496,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/sourcecat/-/sourcecat-1.1.0.tgz",
       "integrity": "sha1-MF/4j/bGEAffosTEbAJ+90qyWPM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "glob": "7.1.2"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.7.0",
+        "function-bind": "1.1.0"
+      }
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -383,17 +519,26 @@
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
-    "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true
-    },
     "tape": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.6.3.tgz",
       "integrity": "sha1-Y353WB6ass4XV36b1M5PV1gG2LY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.0",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.2.2",
+        "resolve": "1.1.7",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -406,12 +551,22 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
@@ -419,7 +574,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.2.0.tgz",
       "integrity": "sha1-ItiGG+3eLbjxji2goAKoQ+VuATU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
+      }
     },
     "urlish": {
       "version": "1.0.1",

--- a/test/logic.js
+++ b/test/logic.js
@@ -204,6 +204,15 @@ test('detects AOLShield Browser', function(t) {
     t.end();
 });
 
+test('detects facebook in-app browser', function (t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 [FBAN/FBIOS;FBAV/157.0.0.42.96;FBBV/90008621;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/11.2.5;FBSS/2;FBCR/Verizon;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]',
+    { name: 'facebook', version: '157.0.0', os: 'iOS' }
+  );
+
+  t.end();
+});
+
 
 test('handles no browser', function(t) {
     assertAgentString(t,

--- a/test/logic.js
+++ b/test/logic.js
@@ -213,6 +213,16 @@ test('detects facebook in-app browser', function (t) {
   t.end();
 });
 
+test('detects instagram in-app browser', function (t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69 Instagram 8.4.0 (iPhone7,2; iPhone OS 9_3_2; nb_NO; nb-NO; scale=2.00; 750x1334',
+    { name: 'instagram', version: '8.4.0', os: 'iOS' }
+  );
+
+  t.end();
+});
+
+
 
 test('handles no browser', function(t) {
     assertAgentString(t,


### PR DESCRIPTION
@DamonOehlman

Following this issue https://github.com/DamonOehlman/detect-browser/issues/56, this PR aims to allow support Facebook and Instagram in-app browsers :iphone: 

**First commit :** Facebook integration
Use of FBAV ( Facebook app version ) to match the browser  https://developers.whatismybrowser.com/useragents/explore/software_name/facebook-app/
**Second commit :** Instagram integration ( Instagram user-agent examples ->  https://mpulp.mobi/2016/07/12/instagram-user-agent/ )
**Third commit :** Update package-lock.json
**Fourth commit :** Minor fix in readme

Tested on iOS device, works perfectly  :+1: 