### PR TITLE
Add bot attribute and test for common bot strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,11 @@ function parseUserAgent(userAgentString) {
     detected.os = detectOS(userAgentString);
   }
 
+  if (/alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!|yandex/i.test(userAgentString)) {
+    detected = detected || {};
+    detected.bot = true;
+  }
+  
   return detected;
 }
 

--- a/test/logic.js
+++ b/test/logic.js
@@ -222,7 +222,23 @@ test('detects instagram in-app browser', function (t) {
   t.end();
 });
 
+test('detects crawlers', function (t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (compatible; AhrefsBot/5.2; +http://ahrefs.com/robot/)',
+    { bot: true }
+  );
 
+  t.end();
+});
+
+test('detects crawlers', function (t) {
+  assertAgentString(t,
+    'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36',
+    { bot: true }
+  );
+
+  t.end();
+});
 
 test('handles no browser', function(t) {
     assertAgentString(t,

--- a/test/logic.js
+++ b/test/logic.js
@@ -222,7 +222,7 @@ test('detects instagram in-app browser', function (t) {
   t.end();
 });
 
-test('detects crawlers', function (t) {
+test('detects crawler: AhrefsBot', function (t) {
   assertAgentString(t,
     'Mozilla/5.0 (compatible; AhrefsBot/5.2; +http://ahrefs.com/robot/)',
     { bot: true }
@@ -231,9 +231,18 @@ test('detects crawlers', function (t) {
   t.end();
 });
 
-test('detects crawlers', function (t) {
+test('detects crawler: GoogleBot', function (t) {
   assertAgentString(t,
     'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36',
+    { bot: true }
+  );
+
+  t.end();
+});
+
+test('detects crawler: YandexBot', function (t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
     { bot: true }
   );
 


### PR DESCRIPTION
This might be a better path to add data if it might be a bot.

Copied from a ruby lib called agent orange:
https://github.com/kevinelliott/agent_orange/blob/f06c3d59452cd21f52261b16a6ea1a5b9b8ac0db/lib/agent_orange/device.rb#L35