### PR TITLE
Add support for Samsung Internet browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function getBrowserRules() {
     [ 'yandexbrowser', /YaBrowser\/([0-9\._]+)/ ],
     [ 'vivaldi', /Vivaldi\/([0-9\.]+)/ ],
     [ 'kakaotalk', /KAKAOTALK\s([0-9\.]+)/ ],
-    [ 'samsung internet', /SamsungBrowser\/([0-9\.]+)/ ],
+    [ 'samsung', /SamsungBrowser\/([0-9\.]+)/ ],
     [ 'chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
     [ 'phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/ ],
     [ 'crios', /CriOS\/([0-9\.]+)(:?\s|$)/ ],

--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ function getBrowserRules() {
     [ 'yandexbrowser', /YaBrowser\/([0-9\._]+)/ ],
     [ 'vivaldi', /Vivaldi\/([0-9\.]+)/ ],
     [ 'kakaotalk', /KAKAOTALK\s([0-9\.]+)/ ],
+    [ 'samsung internet', /SamsungBrowser\/([0-9\.]+)/ ],
     [ 'chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
     [ 'phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/ ],
     [ 'crios', /CriOS\/([0-9\.]+)(:?\s|$)/ ],

--- a/test/logic.js
+++ b/test/logic.js
@@ -225,7 +225,7 @@ test('detects instagram in-app browser', function (t) {
 test('detects Samsung Internet browser', function(t) {
   assertAgentString(t,
     'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-G925F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36',
-    { name: 'samsung internet', version: '4.0.0', os: 'Android OS' }
+    { name: 'samsung', version: '4.0.0', os: 'Android OS' }
   );
 
   t.end();

--- a/test/logic.js
+++ b/test/logic.js
@@ -222,6 +222,15 @@ test('detects instagram in-app browser', function (t) {
   t.end();
 });
 
+test('detects Samsung Internet browser', function(t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-G925F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36',
+    { name: 'samsung internet', version: '4.0.0', os: 'Android OS' }
+  );
+
+  t.end();
+});
+
 test('detects crawler: AhrefsBot', function (t) {
   assertAgentString(t,
     'Mozilla/5.0 (compatible; AhrefsBot/5.2; +http://ahrefs.com/robot/)',


### PR DESCRIPTION
Hello @DamonOehlman! I've been using your package in my code but found that I need support for identifying Samsung Internet (the default web browser on Samsung devices). Currently, when the detect-browser package tries to identify a user agent string for Samsung Internet, it identifies it as Chrome. This PR aims to add support for Samsung Internet.

According to Samsung documentation [here](http://developer.samsung.com/technical-doc/view.do?v=T000000203), the user agent string for Samsung Internet on samsung devices requires the text `SamsungBrowser/version`. I followed these guidelines when creating my regex.