### PR TITLE
Added support for Firefox version strings with semicolon

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function getBrowserRules() {
     [ 'chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/ ],
     [ 'phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/ ],
     [ 'crios', /CriOS\/([0-9\.]+)(:?\s|$)/ ],
-    [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$)/ ],
+    [ 'firefox', /Firefox\/([0-9\.]+)(?:\s|$|;)/ ],
     [ 'fxios', /FxiOS\/([0-9\.]+)/ ],
     [ 'opera', /Opera\/([0-9\.]+)(?:\s|$)/ ],
     [ 'opera', /OPR\/([0-9\.]+)(:?\s|$)$/ ],


### PR DESCRIPTION
Some Firefox versions return a userAgent string in the following format:
"Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0; Firefox 52.7.3 - 111512-1801120036-1.43"
In order to add support for them, the regex was adapted.