### PR TITLE
prioritize browser detection, remove os dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,9 @@
 function detect() {
-  var nodeVersion = getNodeVersion();
-  if (nodeVersion) {
-    return nodeVersion;
-  } else if (typeof navigator !== 'undefined') {
+  if (typeof navigator !== 'undefined') {
     return parseUserAgent(navigator.userAgent);
   }
 
-  return null;
+  return getNodeVersion();
 }
 
 function detectOS(userAgentString) {
@@ -19,12 +16,12 @@ function detectOS(userAgentString) {
 }
 
 function getNodeVersion() {
-  var isNode = typeof navigator === 'undefined' && typeof process !== 'undefined';
-  return isNode ? {
+  var isNode = typeof process !== 'undefined' && process.version;
+  return isNode && {
     name: 'node',
     version: process.version.slice(1),
-    os: require('os').type().toLowerCase()
-  } : null;
+    os: process.platform
+  };
 }
 
 function parseUserAgent(userAgentString) {


### PR DESCRIPTION
So this is a reasonably simple change, but one that should have a pretty big impact for people who have been hit with the code path which is returning a false positive on node detection (see #54).

It changes two things:

1. We do browser detection if at all possible (i.e. `navigator` is defined).  This then falls back to detecting the node environment if that isn't available.

2. Removes the `require('os')` import for os detection and simply uses `process.platform` instead.  The information won't be as detailed and it's possible that a user of this module may still want to opt to do their own check using the `os` module.  Given that the majority use case is web browser detection though I think that makes sense.  Should stop `browserify` bringing in any shims for the `os` module also (which is a good thing).

Because of point 2 though, I believe we should do a major version bump to `3.0.0` to ensure that no-one that is using `detect-browser` in an isomorphic way is caught out unexpectedly.

@5punk PTAL.

/cc @shengshiqi @markgoho-EDT