### PR TITLE
iOS WebView Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function getBrowserRules() {
     [ 'safari', /Version\/([0-9\._]+).*Safari/ ],
     [ 'facebook', /FBAV\/([0-9\.]+)/],
     [ 'instagram', /Instagram\ ([0-9\.]+)/],
-    [ 'ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile$/]
+    [ 'ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile/]
   ]);
 }
 

--- a/test/logic.js
+++ b/test/logic.js
@@ -228,6 +228,11 @@ test('detects native iOS WebView browser', function (t) {
     { name: 'ios-webview', version: '533.17.9', os: 'iOS' }
   );
 
+  assertAgentString(t,
+    'Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E216',
+    { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
Fixes postfixed ios-webview browser.

Some versions of the iOS WebView append a version after Mobile, so the regex has been modified to allow for this.