### PR TITLE
[3.1 planned release] Add the ability to check for particular browser variants

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ function getNodeVersion() {
   return isNode && {
     name: 'node',
     version: process.version.slice(1),
-    os: process.platform
+    os: process.platform,
+    isVariant: function() {
+      return false;
+    }
   };
 }
 
@@ -46,6 +49,7 @@ function parseUserAgent(userAgentString) {
 
   if (detected) {
     detected.os = detectOS(userAgentString);
+    detected.isVariant = lookFor(userAgentString, ['('], [';'])
   }
 
   if (/alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!|yandex/i.test(userAgentString)) {
@@ -121,6 +125,13 @@ function buildRules(ruleTuples) {
       rule: tuple[1]
     };
   });
+}
+
+function lookFor(userAgentString, leadingTokens, trailingTokens) {
+  return function(searchString) {
+    var fullSearchString = leadingTokens.concat([searchString || '']).concat(trailingTokens).join('').toLowerCase();
+    return userAgentString.toLowerCase().indexOf(fullSearchString) >= 0;
+  }
 }
 
 module.exports = {

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./highLevel.js');
 require('./logic.js');
+require('./variants.js');

--- a/test/logic.js
+++ b/test/logic.js
@@ -2,7 +2,11 @@ var test = require('tape');
 var { parseUserAgent } = require('../');
 
 function assertAgentString(t, agentString, expectedResult) {
-  t.deepEqual(parseUserAgent(agentString), expectedResult);
+  const detected = parseUserAgent(agentString);
+  if (detected) {
+    delete detected.isVariant;
+  }
+  t.deepEqual(detected, expectedResult);
 }
 
 test('detects Chrome', function(t) {

--- a/test/variants.js
+++ b/test/variants.js
@@ -1,0 +1,54 @@
+var test = require('tape');
+var { parseUserAgent } = require('../');
+
+test('detects Chrome for iOS (iPhone variant)', function(t) {
+  const browser = parseUserAgent('Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3');
+  t.plan(7);
+  t.ok(browser, 'browser detected');
+  t.equal(browser.name, 'crios');
+  t.equal(browser.isVariant('iPhone'), true);
+  t.equal(browser.isVariant('iphone'), true);
+  t.equal(browser.isVariant('iPad'), false);
+  t.equal(browser.isVariant('ipad'), false);
+  t.equal(browser.isVariant(), false);
+  t.end();
+});
+
+test('detects Chrome for iOS (iPad variant)', function(t) {
+  const browser = parseUserAgent('Mozilla/5.0 (iPad; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3');
+  t.plan(7);
+  t.ok(browser, 'browser detected');
+  t.equal(browser.name, 'crios');
+  t.equal(browser.isVariant('iPhone'), false);
+  t.equal(browser.isVariant('iphone'), false);
+  t.equal(browser.isVariant('iPad'), true);
+  t.equal(browser.isVariant('ipad'), true);
+  t.equal(browser.isVariant(), false);
+  t.end();
+});
+
+test('detects mobile Safari (iPhone variant)', function(t) {
+  const browser = parseUserAgent('Mozilla/5.0 (iPhone; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25');
+  t.plan(7);
+  t.ok(browser, 'browser detected');
+  t.equal(browser.name, 'ios');
+  t.equal(browser.isVariant('iPhone'), true);
+  t.equal(browser.isVariant('iphone'), true);
+  t.equal(browser.isVariant('iPad'), false);
+  t.equal(browser.isVariant('ipad'), false);
+  t.equal(browser.isVariant(), false);
+  t.end();
+});
+
+test('detects mobile Safari (iPad variant)', function(t) {
+  const browser = parseUserAgent('Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25');
+  t.plan(7);
+  t.ok(browser, 'browser detected');
+  t.equal(browser.name, 'ios');
+  t.equal(browser.isVariant('iPhone'), false);
+  t.equal(browser.isVariant('iphone'), false);
+  t.equal(browser.isVariant('iPad'), true);
+  t.equal(browser.isVariant('ipad'), true);
+  t.equal(browser.isVariant(), false);
+  t.end();
+});


### PR DESCRIPTION
This is a potential implementation that would satisfy the request in #69 without having form factor specific terms (mobile, tablet, etc) in function names.  Example usages can be seen in the test files, but a simple example is shown below:

```js
const { detect } = require('detect-browser');
const browser = detect();

// handle the case where we don't detect the browser
if (browser) {
  console.log(browser.name);
  console.log(browser.version);
  console.log(browser.os);

  console.log(browser.isVariant('iPad'));
}
```