### PR TITLE
Fixed instagram regex pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function getBrowserRules() {
     [ 'ios', /Version\/([0-9\._]+).*Mobile.*Safari.*/ ],
     [ 'safari', /Version\/([0-9\._]+).*Safari/ ],
     [ 'facebook', /FBAV\/([0-9\.]+)/],
-    [ 'instagram', /Instagram\ ([0-9\.]+)/],
+    [ 'instagram', /Instagram\s([0-9\.]+)/],
     [ 'ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile/]
   ]);
 }


### PR DESCRIPTION
When I run this module through Webpack minification the literal white space in the Instagram regex pattern gets removed and the escape gets placed on the first opening parentheses. Suggest placing white space character check here instead.

![screen shot 2018-09-10 at 10 53 47 am](https://user-images.githubusercontent.com/5287911/45309041-739ecf00-b4e8-11e8-8e30-9d441eea0fc3.png)

Signed-off-by: Blake Cerecero <Blake@DigitalBlake.com>