### PR TITLE
Added simple TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,13 @@
+export interface BrowserVersion {
+    name: string
+    version: string
+    os: string
+}
+
+export function parseUserAgent(userAgentString: string): BrowserVersion | null;
+
+export function detectOS(userAgentString: string): string | null;
+
+export function getNodeVersion(): BrowserVersion | null;
+
+export function detect(): ReturnType<typeof parseUserAgent | typeof getNodeVersion>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 export interface BrowserVersion {
-    name: string
-    version: string
-    os: string
+    name?: string
+    version?: string
+    os?: string
+    bot?: boolean
 }
 
 export function parseUserAgent(userAgentString: string): BrowserVersion | null;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.1",
   "description": "Unpack a browser type and version from the useragent string",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "node test",
     "prepublish": "npm run test",


### PR DESCRIPTION
These are some initial simple TypeScript typings for the package, as suggested in #74.

They don't try to do anything clever - all data types are simple strings underneath, but it's enough for every TypeScript project using `detect-browser` to at least use it without having to declare the import themselves.

In terms of automated testing with the underlying JS code, I don't think there's a way to ensure they are kept in check, unless the codebase itself was in TS - that is provided as an alternate PR in #77.