### PR TITLE
Minimal source conversion to TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 npm-debug.log
+# Compiled output
+index.js
+index.d.ts
+

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-interface Version {
+export interface Version {
   name?: string
   version?: string
   os?: string

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "pretest": "tsc",
+    "build": "tsc",
+    "pretest": "npm run build",
     "test": "node test",
     "prepublish": "npm run test",
     "patch-release": "npm version patch && npm publish && npm run postpublish",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "3.0.1",
   "description": "Unpack a browser type and version from the useragent string",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
+    "pretest": "tsc",
     "test": "node test",
     "prepublish": "npm run test",
     "patch-release": "npm version patch && npm publish && npm run postpublish",
@@ -29,8 +31,10 @@
   },
   "homepage": "https://github.com/DamonOehlman/detect-browser",
   "devDependencies": {
+    "@types/node": "^10.12.9",
     "embellish-readme": "1.3.2",
     "semver": "^5.0.3",
-    "tape": "^4.2.2"
+    "tape": "^4.2.2",
+    "typescript": "^3.1.6"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "declaration": true,
+    "strict": true
+  },
+  "files": [
+    "index.ts"    
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/node@^10.12.9":
+  version "10.12.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.9.tgz#a07bfa74331471e1dc22a47eb72026843f7b95c8"
+  integrity sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -265,6 +270,11 @@ typedarray-to-buffer@^3.1.2:
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 whisk@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
This is provided as an alternative solution to #74 and an alternate to PR #76. By rewriting the library in TypeScript itself, the type checks can never get out of sync with the API.

The compilation is run as a `pretest` step, which itself is run as a `prepublish` step - but can also be run independently as a `build` step.