### PR TITLE
Remove `Array#find` usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,8 +187,15 @@ export function parseUserAgent(ua: string): BrowserInfo | BotInfo | null {
 }
 
 export function detectOS(ua: string): OperatingSystem | null {
-  const match = operatingSystemRules.find(([_, regex]) => regex.test(ua));
-  return match ? match[0] : null;
+  for (let ii = 0, count = operatingSystemRules.length; ii < count; ii++) {
+    const [os, regex] = operatingSystemRules[ii];
+    const match = regex.test(ua);
+    if (match) {
+      return os;
+    }
+  }
+
+  return null;
 }
 
 export function getNodeVersion(): NodeInfo | null {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "lib": ["es2016", "dom"],
+    "lib": ["es5", "dom"],
     "declaration": true,
     "outDir": "./",
     "rootDir": "./src/",


### PR DESCRIPTION
Additionally, set the `tsconfig.json` file to only expect to have access to `es5` constructs.

Fixes #89.