### PR TITLE
Added support for Webview in iOS v12.1.4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,8 @@ const userAgentRules: UserAgentRule[] = [
   ['safari', /Version\/([0-9\._]+).*Safari/],
   ['facebook', /FBAV\/([0-9\.]+)/],
   ['instagram', /Instagram\s([0-9\.]+)/],
-  ['ios-webview', /AppleWebKit\/([0-9\.]+).*Gecko\)/],
+  ['ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile/],
+  ['ios-webview', /AppleWebKit\/([0-9\.]+).*Gecko\)$/],
   ['searchbot', SEARCHBOX_UA_REGEX],
 ];
 const operatingSystemRules: OperatingSystemRule[] = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ const userAgentRules: UserAgentRule[] = [
   ['safari', /Version\/([0-9\._]+).*Safari/],
   ['facebook', /FBAV\/([0-9\.]+)/],
   ['instagram', /Instagram\s([0-9\.]+)/],
-  ['ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile/],
+  ['ios-webview', /AppleWebKit\/([0-9\.]+).*Gecko\)/],
   ['searchbot', SEARCHBOX_UA_REGEX],
 ];
 const operatingSystemRules: OperatingSystemRule[] = [

--- a/test/logic.js
+++ b/test/logic.js
@@ -233,6 +233,16 @@ test('detects native iOS WebView browser', function (t) {
     { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
   );
 
+  assertAgentString(t,
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B92',
+    { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
+  );
+
+  assertAgentString(t,
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)',
+    { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
+  );
+
   t.end();
 });
 

--- a/test/logic.js
+++ b/test/logic.js
@@ -16,6 +16,11 @@ test('detects Chrome', function(t) {
     { name: 'chrome', version: '41.0.2228', os: 'Windows 7' }
   );
 
+  assertAgentString(t,
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36',
+    { name: 'chrome', version: '72.0.3626', os: 'Windows 10' }
+  )
+  
   t.end();
 });
 


### PR DESCRIPTION
iOS version 12.1.4 has a slightly different userAgent for the webview browser. The new version no longer contains the word "Mobile".

Example:
```
iOS 12.1.4:
Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)
iOS 12.1:
Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B92
```

This means that the previous regex  `/AppleWebKit\/([0-9\.]+).*Mobile/` doesn't work. I have modified the regex to instead check for `Gecko)` which seems to only appear in the Webview and works for the unit tests in `logic.js`.

