### PR TITLE
add detection for miui browser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ type Browser =
   | 'kakaotalk'
   | 'samsung'
   | 'silk'
+  | 'miui'
   | 'chrome'
   | 'phantomjs'
   | 'crios'
@@ -95,6 +96,7 @@ const userAgentRules: UserAgentRule[] = [
   ['kakaotalk', /KAKAOTALK\s([0-9\.]+)/],
   ['samsung', /SamsungBrowser\/([0-9\.]+)/],
   ['silk', /\bSilk\/([0-9._-]+)\b/],
+  ['miui', /MiuiBrowser\/([0-9\.]+)$/],
   ['chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/],
   ['phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/],
   ['crios', /CriOS\/([0-9\.]+)(:?\s|$)/],

--- a/test/logic.js
+++ b/test/logic.js
@@ -20,7 +20,7 @@ test('detects Chrome', function(t) {
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36',
     { name: 'chrome', version: '72.0.3626', os: 'Windows 10' }
   )
-  
+
   t.end();
 });
 
@@ -292,7 +292,7 @@ test('detects Opera-Mini', function (t) {
     'Opera/9.80 (Android; Opera Mini/8.0.1807/36.1609; U; en) Presto/2.12.423 Version/12.16',
     { name: 'opera-mini', version: '12.16.0', os: 'Android OS' }
   );
-  
+
   assertAgentString(t,
     'Opera/9.80 (BlackBerry; Opera Mini/6.5.27548/27.2020; U; en) Presto/2.8.119 Version/11.10',
     { name: 'opera-mini', version: '11.10.0', os: 'BlackBerry OS' }
@@ -324,10 +324,18 @@ test('detects Chrome OS', function (t) {
     'Mozilla/5.0 (X11; CrOS x86_64 10895.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.120 Safari/537.36',
     { name: 'chrome', version: '69.0.3497', os: 'Chrome OS' }
   );
-  
+
   assertAgentString(t,
     'Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Gecko/20100101 Firefox/29.0',
     { name: 'firefox', version: '29.0.0', os: 'Chrome OS' }
+  );
+  t.end();
+});
+
+test('detects miui', function(t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (Linux; U; Android 7.0; en-us; MI 5 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.146 Mobile Safari/537.36 XiaoMi/MiuiBrowser/9.0.3',
+    { name: 'miui', version: '9.0.3', os: 'Android OS' }
   );
   t.end();
 });


### PR DESCRIPTION
Resolves #97 

UA:

```
Mozilla/5.0 (Linux; U; Android 7.0; en-us; MI 5 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.146 Mobile Safari/537.36 XiaoMi/MiuiBrowser/9.0.3
```

Detection result:

```js
{ name: 'miui', version: '9.0.3', os: 'Android OS' }
```

NOTE - prior to this change the browser would have been detected as a chrome browser, so that will need to be made mention of in the release notes.  This is very similar to the Samsung internet browser behaviour though so shouldn't be an unexpected change to users who might be expecting chrome.