### PR TITLE
add detection for new edge chromium browser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ type Browser =
   | 'silk'
   | 'miui'
   | 'beaker'
+  | 'edge-chromium'
   | 'chrome'
   | 'phantomjs'
   | 'crios'
@@ -99,6 +100,7 @@ const userAgentRules: UserAgentRule[] = [
   ['silk', /\bSilk\/([0-9._-]+)\b/],
   ['miui', /MiuiBrowser\/([0-9\.]+)$/],
   ['beaker', /BeakerBrowser\/([0-9\.]+)/],
+  ['edge-chromium', /Edg\/([0-9\.]+)/],
   ['chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/],
   ['phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/],
   ['crios', /CriOS\/([0-9\.]+)(:?\s|$)/],

--- a/test/logic.js
+++ b/test/logic.js
@@ -345,6 +345,7 @@ test('detects Beaker Browser', function(t) {
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) BeakerBrowser/0.8.7 Chrome/69.0.3497.128 Electron/4.1.3 Safari/537.36',
     { name: 'beaker', version: '0.8.7', os: 'Windows 10' }
   );
+  t.end();
 });
 
 test('detects edge chromium', function(t) {

--- a/test/logic.js
+++ b/test/logic.js
@@ -345,8 +345,15 @@ test('detects Beaker Browser', function(t) {
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) BeakerBrowser/0.8.7 Chrome/69.0.3497.128 Electron/4.1.3 Safari/537.36',
     { name: 'beaker', version: '0.8.7', os: 'Windows 10' }
   );
+});
+
+test('detects edge chromium', function(t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24',
+    { name: 'edge-chromium', version: '74.1.96', os: 'Windows 10' }
+  );
   t.end();
-})
+});
 
 test('handles no browser', function(t) {
     assertAgentString(t,


### PR DESCRIPTION
Will be interesting to see if MS retain the shortened `Edg` vs `Edge` in the user agent string (I doubt it). As such I expect this is a detection that will become redundant as MS transitions to chromium backed edge in stable, but I think it's probably a worthwhile detection to add for now in case anyone wants to give it special treatment in the interim.

```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24
```