### PR TITLE
Add fix for Opera Developer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ const userAgentRules: UserAgentRule[] = [
   ['fxios', /FxiOS\/([0-9\.]+)/],
   ['opera-mini', /Opera Mini.*Version\/([0-9\.]+)/],
   ['opera', /Opera\/([0-9\.]+)(?:\s|$)/],
-  ['opera', /OPR\/([0-9\.]+)(:?\s|$)$/],
+  ['opera', /OPR\/([0-9\.]+)(:?\s|$)/],
   ['ie', /Trident\/7\.0.*rv\:([0-9\.]+).*\).*Gecko$/],
   ['ie', /MSIE\s([0-9\.]+);.*Trident\/[4-7].0/],
   ['ie', /MSIE\s(7\.0)/],


### PR DESCRIPTION
navigator.userAgent = “Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.28 Safari/537.36 OPR/61.0.3282.0 (Edition developer)"