### PR TITLE
add support for edge-ios detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ type Browser =
   | 'ie'
   | 'bb10'
   | 'android'
+  | 'edge-ios'
   | 'ios'
   | 'safari'
   | 'facebook'
@@ -114,6 +115,7 @@ const userAgentRules: UserAgentRule[] = [
   ['ie', /MSIE\s(7\.0)/],
   ['bb10', /BB10;\sTouch.*Version\/([0-9\.]+)/],
   ['android', /Android\s([0-9\.]+)/],
+  ['edge-ios', /EdgiOS\/([0-9\.]+)/],
   ['ios', /Version\/([0-9\._]+).*Mobile.*Safari.*/],
   ['safari', /Version\/([0-9\._]+).*Safari/],
   ['facebook', /FBAV\/([0-9\.]+)/],

--- a/test/logic.js
+++ b/test/logic.js
@@ -361,6 +361,14 @@ test('detects edge chromium', function(t) {
   t.end();
 });
 
+test('detects edge chromium (iOS)', function(t) {
+  assertAgentString(t,
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/44.2.1 Mobile/16D57 Safari/605.1.15',
+    { name: 'edge-ios', version: '44.2.1', os: 'iOS' }
+  );
+  t.end();
+})
+
 test('handles no browser', function(t) {
     assertAgentString(t,
         null,


### PR DESCRIPTION
This is in response to #105 and I think the correct solution, given MS are uniquely identifying this with an `EdgiOS` in the user agent string.  The other alternative is to identify it as `edge` with operating system of `iOS`. but I think that may involve more work and may not represent how different edge & edge for iOS actually are (going to do a little bit of an investigation around this).

Anyway... it works.

/cc @keisnet