### PR TITLE
chore: install prettier so I am not fighting format on save

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,2 +1,2 @@
 singleQuote: true
-trailingComma: "es5"
+trailingComma: "all"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,2 @@
 singleQuote: true
+trailingComma: "es5"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "minor-release": "npm version minor && npm publish && npm run postpublish",
     "major-release": "npm version major && npm publish && npm run postpublish",
     "postpublish": "git push origin master --follow-tags",
+    "autoformat": "prettier --write src/** test/**",
     "gendocs": "embellish README.md"
   },
   "stability": "stable",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/node": "^10.12.12",
     "embellish-readme": "1.3.2",
+    "prettier": "^1.18.2",
     "semver": "^5.0.3",
     "tape": "^4.2.2",
     "tslint": "^5.11.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ const userAgentRules: UserAgentRule[] = [
   ['edge-chromium', /Edg\/([0-9\.]+)/],
   [
     'chromium-webview',
-    /(?!Chrom.*OPR)wv\).*Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/
+    /(?!Chrom.*OPR)wv\).*Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/,
   ],
   ['chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/],
   ['phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/],
@@ -125,7 +125,7 @@ const userAgentRules: UserAgentRule[] = [
   ['instagram', /Instagram\s([0-9\.]+)/],
   ['ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile/],
   ['ios-webview', /AppleWebKit\/([0-9\.]+).*Gecko\)$/],
-  ['searchbot', SEARCHBOX_UA_REGEX]
+  ['searchbot', SEARCHBOX_UA_REGEX],
 ];
 const operatingSystemRules: OperatingSystemRule[] = [
   ['iOS', /iP(hone|od|ad)/],
@@ -153,7 +153,7 @@ const operatingSystemRules: OperatingSystemRule[] = [
   ['QNX', /QNX/],
   ['BeOS', /BeOS/],
   ['OS/2', /OS\/2/],
-  ['Search Bot', SEARCHBOT_OS_REGEX]
+  ['Search Bot', SEARCHBOT_OS_REGEX],
 ];
 
 export function detect(
@@ -202,7 +202,7 @@ export function parseUserAgent(ua: string): BrowserInfo | BotInfo | null {
     if (versionParts.length < REQUIRED_VERSION_PARTS) {
       versionParts = [
         ...versionParts,
-        ...createVersionParts(REQUIRED_VERSION_PARTS - versionParts.length)
+        ...createVersionParts(REQUIRED_VERSION_PARTS - versionParts.length),
       ];
     }
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,20 +4,20 @@ interface DetectedInfo<N extends string, O, V = null> {
   readonly os: O;
 }
 
-export class BrowserInfo implements DetectedInfo<Browser, OperatingSystem | null, string> {
+export class BrowserInfo
+  implements DetectedInfo<Browser, OperatingSystem | null, string> {
   constructor(
     public readonly name: Browser,
     public readonly version: string,
-    public readonly os: OperatingSystem | null) {
-  }
+    public readonly os: OperatingSystem | null
+  ) {}
 }
 
 export class NodeInfo implements DetectedInfo<'node', NodeJS.Platform, string> {
   public readonly name: 'node' = 'node';
   public readonly os: NodeJS.Platform = process.platform;
 
-  constructor( public readonly version: string) {
-  }
+  constructor(public readonly version: string) {}
 }
 
 export class BotInfo implements DetectedInfo<'bot', null, null> {
@@ -102,7 +102,10 @@ const userAgentRules: UserAgentRule[] = [
   ['miui', /MiuiBrowser\/([0-9\.]+)$/],
   ['beaker', /BeakerBrowser\/([0-9\.]+)/],
   ['edge-chromium', /Edg\/([0-9\.]+)/],
-  ['chromium-webview', /(?!Chrom.*OPR)wv\).*Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/],
+  [
+    'chromium-webview',
+    /(?!Chrom.*OPR)wv\).*Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/
+  ],
   ['chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/],
   ['phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/],
   ['crios', /CriOS\/([0-9\.]+)(:?\s|$)/],
@@ -122,7 +125,7 @@ const userAgentRules: UserAgentRule[] = [
   ['instagram', /Instagram\s([0-9\.]+)/],
   ['ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile/],
   ['ios-webview', /AppleWebKit\/([0-9\.]+).*Gecko\)$/],
-  ['searchbot', SEARCHBOX_UA_REGEX],
+  ['searchbot', SEARCHBOX_UA_REGEX]
 ];
 const operatingSystemRules: OperatingSystemRule[] = [
   ['iOS', /iP(hone|od|ad)/],
@@ -150,10 +153,12 @@ const operatingSystemRules: OperatingSystemRule[] = [
   ['QNX', /QNX/],
   ['BeOS', /BeOS/],
   ['OS/2', /OS\/2/],
-  ['Search Bot', SEARCHBOT_OS_REGEX],
+  ['Search Bot', SEARCHBOT_OS_REGEX]
 ];
 
-export function detect(userAgent?: string): BrowserInfo | BotInfo | NodeInfo | null {
+export function detect(
+  userAgent?: string
+): BrowserInfo | BotInfo | NodeInfo | null {
   if (!!userAgent) {
     return parseUserAgent(userAgent);
   }
@@ -172,14 +177,17 @@ export function parseUserAgent(ua: string): BrowserInfo | BotInfo | null {
   // probably something that needs to be benchmarked though
   const matchedRule: UserAgentMatch =
     ua !== '' &&
-    userAgentRules.reduce<UserAgentMatch>((matched: UserAgentMatch, [browser, regex]) => {
-      if (matched) {
-        return matched;
-      }
+    userAgentRules.reduce<UserAgentMatch>(
+      (matched: UserAgentMatch, [browser, regex]) => {
+        if (matched) {
+          return matched;
+        }
 
-      const uaMatch = regex.exec(ua);
-      return !!uaMatch && [browser, uaMatch];
-    }, false);
+        const uaMatch = regex.exec(ua);
+        return !!uaMatch && [browser, uaMatch];
+      },
+      false
+    );
 
   if (!matchedRule) {
     return null;
@@ -194,7 +202,7 @@ export function parseUserAgent(ua: string): BrowserInfo | BotInfo | null {
     if (versionParts.length < REQUIRED_VERSION_PARTS) {
       versionParts = [
         ...versionParts,
-        ...createVersionParts(REQUIRED_VERSION_PARTS - versionParts.length),
+        ...createVersionParts(REQUIRED_VERSION_PARTS - versionParts.length)
       ];
     }
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export class BrowserInfo
   constructor(
     public readonly name: Browser,
     public readonly version: string,
-    public readonly os: OperatingSystem | null
+    public readonly os: OperatingSystem | null,
   ) {}
 }
 
@@ -157,7 +157,7 @@ const operatingSystemRules: OperatingSystemRule[] = [
 ];
 
 export function detect(
-  userAgent?: string
+  userAgent?: string,
 ): BrowserInfo | BotInfo | NodeInfo | null {
   if (!!userAgent) {
     return parseUserAgent(userAgent);
@@ -186,7 +186,7 @@ export function parseUserAgent(ua: string): BrowserInfo | BotInfo | null {
         const uaMatch = regex.exec(ua);
         return !!uaMatch && [browser, uaMatch];
       },
-      false
+      false,
     );
 
   if (!matchedRule) {

--- a/test/logic.js
+++ b/test/logic.js
@@ -123,7 +123,7 @@ test('detects Opera', function(t) {
   assertAgentString(t, 'Opera/9.25 (Macintosh; Intel Mac OS X; U; en)', {
     name: 'opera',
     version: '9.25.0',
-    os: 'Mac OS'
+    os: 'Mac OS',
   });
 
   assertAgentString(

--- a/test/logic.js
+++ b/test/logic.js
@@ -9,19 +9,19 @@ test('detects Chrome', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36',
-    { name: 'chrome', version: '50.0.2661', os: 'Linux' }
+    { name: 'chrome', version: '50.0.2661', os: 'Linux' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
-    { name: 'chrome', version: '41.0.2228', os: 'Windows 7' }
+    { name: 'chrome', version: '41.0.2228', os: 'Windows 7' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36',
-    { name: 'chrome', version: '72.0.3626', os: 'Windows 10' }
+    { name: 'chrome', version: '72.0.3626', os: 'Windows 10' },
   );
 
   t.end();
@@ -31,7 +31,7 @@ test('detects Chrome for iOS', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3',
-    { name: 'crios', version: '19.0.1084', os: 'iOS' }
+    { name: 'crios', version: '19.0.1084', os: 'iOS' },
   );
 
   t.end();
@@ -41,13 +41,13 @@ test('detects Firefox', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0',
-    { name: 'firefox', version: '46.0.0', os: 'Linux' }
+    { name: 'firefox', version: '46.0.0', os: 'Linux' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
-    { name: 'firefox', version: '40.1.0', os: 'Windows 7' }
+    { name: 'firefox', version: '40.1.0', os: 'Windows 7' },
   );
 
   t.end();
@@ -57,13 +57,13 @@ test('detects Firefox for iOS', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
-    { name: 'fxios', version: '1.0.0', os: 'iOS' }
+    { name: 'fxios', version: '1.0.0', os: 'iOS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/3.2 Mobile/12F69 Safari/600.1.4',
-    { name: 'fxios', version: '3.2.0', os: 'iOS' }
+    { name: 'fxios', version: '3.2.0', os: 'iOS' },
   );
 
   t.end();
@@ -73,13 +73,13 @@ test('detects Edge', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
-    { name: 'edge', version: '12.246.0', os: 'Windows 10' }
+    { name: 'edge', version: '12.246.0', os: 'Windows 10' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 6.3; Win64, x64; Touch) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0 (Touch; Trident/7.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; HPNTDFJS; H9P; InfoPath',
-    { name: 'edge', version: '12.0.0', os: 'Windows 8.1' }
+    { name: 'edge', version: '12.0.0', os: 'Windows 8.1' },
   );
 
   t.end();
@@ -89,25 +89,25 @@ test('detects IE', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko',
-    { name: 'ie', version: '11.0.0', os: 'Windows 8.1' }
+    { name: 'ie', version: '11.0.0', os: 'Windows 8.1' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0; MSN 11.61; MSNbMSNI; MSNmen-us; MSNcOTH) like Gecko',
-    { name: 'ie', version: '11.0.0', os: 'Windows 10' }
+    { name: 'ie', version: '11.0.0', os: 'Windows 10' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0',
-    { name: 'ie', version: '10.6.0', os: 'Windows 7' }
+    { name: 'ie', version: '10.6.0', os: 'Windows 7' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 5.2; WOW64; .NET CLR 2.0.50727)',
-    { name: 'ie', version: '7.0.0', os: 'Windows Server 2003' }
+    { name: 'ie', version: '7.0.0', os: 'Windows Server 2003' },
   );
 
   t.end();
@@ -117,7 +117,7 @@ test('detects Opera', function(t) {
   assertAgentString(
     t,
     'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/886; U; en) Presto/2.4.15',
-    { name: 'opera', version: '9.80.0', os: 'Windows XP' }
+    { name: 'opera', version: '9.80.0', os: 'Windows XP' },
   );
 
   assertAgentString(t, 'Opera/9.25 (Macintosh; Intel Mac OS X; U; en)', {
@@ -129,13 +129,13 @@ test('detects Opera', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36 OPR/38.0.2220.31',
-    { name: 'opera', version: '38.0.2220', os: 'Mac OS' }
+    { name: 'opera', version: '38.0.2220', os: 'Mac OS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.28 Safari/537.36 OPR/61.0.3282.0 (Edition developer)',
-    { name: 'opera', version: '61.0.3282', os: 'Mac OS' }
+    { name: 'opera', version: '61.0.3282', os: 'Mac OS' },
   );
 
   t.end();
@@ -145,7 +145,7 @@ test('detects BlackBerry 10', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/7.2.0.0 Mobile Safari/537.10+',
-    { name: 'bb10', version: '7.2.0', os: 'BlackBerry OS' }
+    { name: 'bb10', version: '7.2.0', os: 'BlackBerry OS' },
   );
 
   t.end();
@@ -155,7 +155,7 @@ test('detects Android Webkit browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
-    { name: 'android', version: '4.0.3', os: 'Android OS' }
+    { name: 'android', version: '4.0.3', os: 'Android OS' },
   );
 
   t.end();
@@ -165,13 +165,13 @@ test('detects mobile Safari', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25',
-    { name: 'ios', version: '6.0.0', os: 'iOS' }
+    { name: 'ios', version: '6.0.0', os: 'iOS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5',
-    { name: 'ios', version: '5.0.2', os: 'iOS' }
+    { name: 'ios', version: '5.0.2', os: 'iOS' },
   );
 
   t.end();
@@ -181,7 +181,7 @@ test('detects Safari', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A',
-    { name: 'safari', version: '7.0.3', os: 'Mac OS' }
+    { name: 'safari', version: '7.0.3', os: 'Mac OS' },
   );
 
   t.end();
@@ -191,7 +191,7 @@ test('detects Yandex Browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 YaBrowser/16.10.0.2774 Safari/537.36',
-    { name: 'yandexbrowser', version: '16.10.0', os: 'Mac OS' }
+    { name: 'yandexbrowser', version: '16.10.0', os: 'Mac OS' },
   );
 
   t.end();
@@ -201,7 +201,7 @@ test('detects Vivaldi Browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43',
-    { name: 'vivaldi', version: '1.2.490', os: 'Mac OS' }
+    { name: 'vivaldi', version: '1.2.490', os: 'Mac OS' },
   );
 
   t.end();
@@ -211,13 +211,13 @@ test('detects Kakaotalk Browser', function(t) {
   assertAgentString(
     t,
     'Netscape 5.0 (iPhone; CPU iPhone OS 10_3 1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E304 KAKAOTALK 6.2.2',
-    { name: 'kakaotalk', version: '6.2.2', os: 'iOS' }
+    { name: 'kakaotalk', version: '6.2.2', os: 'iOS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS  10_3 1 like Mac OS X) AppleWebKit/  603.1.30 (KHTML, like Gecko) Mobile/ 14E304 KAKAOTALK 6.2.2',
-    { name: 'kakaotalk', version: '6.2.2', os: 'iOS' }
+    { name: 'kakaotalk', version: '6.2.2', os: 'iOS' },
   );
 
   t.end();
@@ -227,7 +227,7 @@ test('detects PhantomJS Browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1',
-    { name: 'phantomjs', version: '2.1.1', os: 'Mac OS' }
+    { name: 'phantomjs', version: '2.1.1', os: 'Mac OS' },
   );
 
   t.end();
@@ -237,7 +237,7 @@ test('detects AOLShield Browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2841.00 Safari/537.36 AOLShield/54.0.2848.0',
-    { name: 'aol', version: '54.0.2848', os: 'Windows 10' }
+    { name: 'aol', version: '54.0.2848', os: 'Windows 10' },
   );
 
   t.end();
@@ -247,7 +247,7 @@ test('detects facebook in-app browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 [FBAN/FBIOS;FBAV/157.0.0.42.96;FBBV/90008621;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/11.2.5;FBSS/2;FBCR/Verizon;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]',
-    { name: 'facebook', version: '157.0.0', os: 'iOS' }
+    { name: 'facebook', version: '157.0.0', os: 'iOS' },
   );
 
   t.end();
@@ -257,7 +257,7 @@ test('detects instagram in-app browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69 Instagram 8.4.0 (iPhone7,2; iPhone OS 9_3_2; nb_NO; nb-NO; scale=2.00; 750x1334',
-    { name: 'instagram', version: '8.4.0', os: 'iOS' }
+    { name: 'instagram', version: '8.4.0', os: 'iOS' },
   );
 
   t.end();
@@ -267,25 +267,25 @@ test('detects native iOS WebView browser', function(t) {
   assertAgentString(
     t,
     'User-Agent: Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile',
-    { name: 'ios-webview', version: '533.17.9', os: 'iOS' }
+    { name: 'ios-webview', version: '533.17.9', os: 'iOS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E216',
-    { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
+    { name: 'ios-webview', version: '605.1.15', os: 'iOS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B92',
-    { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
+    { name: 'ios-webview', version: '605.1.15', os: 'iOS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)',
-    { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
+    { name: 'ios-webview', version: '605.1.15', os: 'iOS' },
   );
 
   t.end();
@@ -295,7 +295,7 @@ test('detects Samsung Internet browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-G925F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36',
-    { name: 'samsung', version: '4.0.0', os: 'Android OS' }
+    { name: 'samsung', version: '4.0.0', os: 'Android OS' },
   );
 
   t.end();
@@ -305,7 +305,7 @@ test('detects crawler: AhrefsBot', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (compatible; AhrefsBot/5.2; +http://ahrefs.com/robot/)',
-    { bot: true, name: 'bot', version: null, os: null }
+    { bot: true, name: 'bot', version: null, os: null },
   );
 
   t.end();
@@ -315,7 +315,7 @@ test('detects crawler: GoogleBot', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36',
-    { bot: true, name: 'bot', version: null, os: null }
+    { bot: true, name: 'bot', version: null, os: null },
   );
 
   t.end();
@@ -325,7 +325,7 @@ test('detects crawler: YandexBot', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
-    { bot: true, name: 'bot', version: null, os: null }
+    { bot: true, name: 'bot', version: null, os: null },
   );
 
   t.end();
@@ -335,13 +335,13 @@ test('detects Opera-Mini', function(t) {
   assertAgentString(
     t,
     'Opera/9.80 (Android; Opera Mini/8.0.1807/36.1609; U; en) Presto/2.12.423 Version/12.16',
-    { name: 'opera-mini', version: '12.16.0', os: 'Android OS' }
+    { name: 'opera-mini', version: '12.16.0', os: 'Android OS' },
   );
 
   assertAgentString(
     t,
     'Opera/9.80 (BlackBerry; Opera Mini/6.5.27548/27.2020; U; en) Presto/2.8.119 Version/11.10',
-    { name: 'opera-mini', version: '11.10.0', os: 'BlackBerry OS' }
+    { name: 'opera-mini', version: '11.10.0', os: 'BlackBerry OS' },
   );
   t.end();
 });
@@ -350,19 +350,19 @@ test('detects Silk', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Linux; Android 4.4.3; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Safari/537.36',
-    { name: 'silk', version: '44.1.54', os: 'Android OS' }
+    { name: 'silk', version: '44.1.54', os: 'Android OS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Safari/537.36',
-    { name: 'silk', version: '44.1.54', os: 'Linux' }
+    { name: 'silk', version: '44.1.54', os: 'Linux' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (Linux; U; Android 4.4.3; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Mobile Safari/537.36',
-    { name: 'silk', version: '44.1.54', os: 'Android OS' }
+    { name: 'silk', version: '44.1.54', os: 'Android OS' },
   );
 
   t.end();
@@ -372,13 +372,13 @@ test('detects Chrome OS', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (X11; CrOS x86_64 10895.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.120 Safari/537.36',
-    { name: 'chrome', version: '69.0.3497', os: 'Chrome OS' }
+    { name: 'chrome', version: '69.0.3497', os: 'Chrome OS' },
   );
 
   assertAgentString(
     t,
     'Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Gecko/20100101 Firefox/29.0',
-    { name: 'firefox', version: '29.0.0', os: 'Chrome OS' }
+    { name: 'firefox', version: '29.0.0', os: 'Chrome OS' },
   );
   t.end();
 });
@@ -387,7 +387,7 @@ test('detects miui', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Linux; U; Android 7.0; en-us; MI 5 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.146 Mobile Safari/537.36 XiaoMi/MiuiBrowser/9.0.3',
-    { name: 'miui', version: '9.0.3', os: 'Android OS' }
+    { name: 'miui', version: '9.0.3', os: 'Android OS' },
   );
   t.end();
 });
@@ -396,7 +396,7 @@ test('detects Beaker Browser', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) BeakerBrowser/0.8.7 Chrome/69.0.3497.128 Electron/4.1.3 Safari/537.36',
-    { name: 'beaker', version: '0.8.7', os: 'Windows 10' }
+    { name: 'beaker', version: '0.8.7', os: 'Windows 10' },
   );
   t.end();
 });
@@ -405,7 +405,7 @@ test('detects edge chromium', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24',
-    { name: 'edge-chromium', version: '74.1.96', os: 'Windows 10' }
+    { name: 'edge-chromium', version: '74.1.96', os: 'Windows 10' },
   );
   t.end();
 });
@@ -421,7 +421,7 @@ test('detects Chromium-based WebView On Android', function(t) {
   assertAgentString(
     t,
     'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36',
-    { name: 'chromium-webview', version: '43.0.2357', os: 'Android OS' }
+    { name: 'chromium-webview', version: '43.0.2357', os: 'Android OS' },
   );
   t.end();
 });

--- a/test/logic.js
+++ b/test/logic.js
@@ -6,26 +6,30 @@ function assertAgentString(t, agentString, expectedResult) {
 }
 
 test('detects Chrome', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36',
     { name: 'chrome', version: '50.0.2661', os: 'Linux' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
     { name: 'chrome', version: '41.0.2228', os: 'Windows 7' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36',
     { name: 'chrome', version: '72.0.3626', os: 'Windows 10' }
-  )
+  );
 
   t.end();
 });
 
 test('detects Chrome for iOS', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3',
     { name: 'crios', version: '19.0.1084', os: 'iOS' }
   );
@@ -34,12 +38,14 @@ test('detects Chrome for iOS', function(t) {
 });
 
 test('detects Firefox', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:46.0) Gecko/20100101 Firefox/46.0',
     { name: 'firefox', version: '46.0.0', os: 'Linux' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1',
     { name: 'firefox', version: '40.1.0', os: 'Windows 7' }
   );
@@ -48,12 +54,14 @@ test('detects Firefox', function(t) {
 });
 
 test('detects Firefox for iOS', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
     { name: 'fxios', version: '1.0.0', os: 'iOS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/3.2 Mobile/12F69 Safari/600.1.4',
     { name: 'fxios', version: '3.2.0', os: 'iOS' }
   );
@@ -62,12 +70,14 @@ test('detects Firefox for iOS', function(t) {
 });
 
 test('detects Edge', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
     { name: 'edge', version: '12.246.0', os: 'Windows 10' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 6.3; Win64, x64; Touch) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0 (Touch; Trident/7.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; HPNTDFJS; H9P; InfoPath',
     { name: 'edge', version: '12.0.0', os: 'Windows 8.1' }
   );
@@ -76,22 +86,26 @@ test('detects Edge', function(t) {
 });
 
 test('detects IE', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko',
     { name: 'ie', version: '11.0.0', os: 'Windows 8.1' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0; MSN 11.61; MSNbMSNI; MSNmen-us; MSNcOTH) like Gecko',
     { name: 'ie', version: '11.0.0', os: 'Windows 10' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0',
     { name: 'ie', version: '10.6.0', os: 'Windows 7' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 5.2; WOW64; .NET CLR 2.0.50727)',
     { name: 'ie', version: '7.0.0', os: 'Windows Server 2003' }
   );
@@ -100,31 +114,36 @@ test('detects IE', function(t) {
 });
 
 test('detects Opera', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Opera/9.80 (J2ME/MIDP; Opera Mini/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/886; U; en) Presto/2.4.15',
     { name: 'opera', version: '9.80.0', os: 'Windows XP' }
   );
 
-  assertAgentString(t,
-    'Opera/9.25 (Macintosh; Intel Mac OS X; U; en)',
-    { name: 'opera', version: '9.25.0', os: 'Mac OS' }
-  );
+  assertAgentString(t, 'Opera/9.25 (Macintosh; Intel Mac OS X; U; en)', {
+    name: 'opera',
+    version: '9.25.0',
+    os: 'Mac OS'
+  });
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36 OPR/38.0.2220.31',
     { name: 'opera', version: '38.0.2220', os: 'Mac OS' }
   );
 
-  assertAgentString(t,
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.28 Safari/537.36 OPR/61.0.3282.0 (Edition developer)',
-      { name: 'opera', version: '61.0.3282', os: 'Mac OS' }
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.28 Safari/537.36 OPR/61.0.3282.0 (Edition developer)',
+    { name: 'opera', version: '61.0.3282', os: 'Mac OS' }
   );
 
   t.end();
 });
 
 test('detects BlackBerry 10', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/7.2.0.0 Mobile Safari/537.10+',
     { name: 'bb10', version: '7.2.0', os: 'BlackBerry OS' }
   );
@@ -133,7 +152,8 @@ test('detects BlackBerry 10', function(t) {
 });
 
 test('detects Android Webkit browser', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     { name: 'android', version: '4.0.3', os: 'Android OS' }
   );
@@ -142,12 +162,14 @@ test('detects Android Webkit browser', function(t) {
 });
 
 test('detects mobile Safari', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25',
     { name: 'ios', version: '6.0.0', os: 'iOS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5',
     { name: 'ios', version: '5.0.2', os: 'iOS' }
   );
@@ -156,7 +178,8 @@ test('detects mobile Safari', function(t) {
 });
 
 test('detects Safari', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A',
     { name: 'safari', version: '7.0.3', os: 'Mac OS' }
   );
@@ -165,57 +188,64 @@ test('detects Safari', function(t) {
 });
 
 test('detects Yandex Browser', function(t) {
-    assertAgentString(t,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 YaBrowser/16.10.0.2774 Safari/537.36',
-        { name: 'yandexbrowser', version: '16.10.0', os: 'Mac OS' }
-    );
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 YaBrowser/16.10.0.2774 Safari/537.36',
+    { name: 'yandexbrowser', version: '16.10.0', os: 'Mac OS' }
+  );
 
-    t.end();
+  t.end();
 });
 
 test('detects Vivaldi Browser', function(t) {
-    assertAgentString(t,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43',
-        { name: 'vivaldi', version: '1.2.490', os: 'Mac OS' }
-    );
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 Vivaldi/1.2.490.43',
+    { name: 'vivaldi', version: '1.2.490', os: 'Mac OS' }
+  );
 
-    t.end();
+  t.end();
 });
 
 test('detects Kakaotalk Browser', function(t) {
-    assertAgentString(t,
-        'Netscape 5.0 (iPhone; CPU iPhone OS 10_3 1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E304 KAKAOTALK 6.2.2',
-        { name: 'kakaotalk', version: '6.2.2', os: 'iOS' }
-    );
+  assertAgentString(
+    t,
+    'Netscape 5.0 (iPhone; CPU iPhone OS 10_3 1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E304 KAKAOTALK 6.2.2',
+    { name: 'kakaotalk', version: '6.2.2', os: 'iOS' }
+  );
 
-    assertAgentString(t,
-        'Mozilla/5.0 (iPhone; CPU iPhone OS  10_3 1 like Mac OS X) AppleWebKit/  603.1.30 (KHTML, like Gecko) Mobile/ 14E304 KAKAOTALK 6.2.2',
-        { name: 'kakaotalk', version: '6.2.2', os: 'iOS' }
-    );
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (iPhone; CPU iPhone OS  10_3 1 like Mac OS X) AppleWebKit/  603.1.30 (KHTML, like Gecko) Mobile/ 14E304 KAKAOTALK 6.2.2',
+    { name: 'kakaotalk', version: '6.2.2', os: 'iOS' }
+  );
 
-    t.end();
+  t.end();
 });
 
 test('detects PhantomJS Browser', function(t) {
-    assertAgentString(t,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1',
-        { name: 'phantomjs', version: '2.1.1', os: 'Mac OS' }
-    );
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1',
+    { name: 'phantomjs', version: '2.1.1', os: 'Mac OS' }
+  );
 
-    t.end();
+  t.end();
 });
 
 test('detects AOLShield Browser', function(t) {
-    assertAgentString(t,
-        'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2841.00 Safari/537.36 AOLShield/54.0.2848.0',
-        { name: 'aol', version: '54.0.2848', os: 'Windows 10' }
-    );
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2841.00 Safari/537.36 AOLShield/54.0.2848.0',
+    { name: 'aol', version: '54.0.2848', os: 'Windows 10' }
+  );
 
-    t.end();
+  t.end();
 });
 
-test('detects facebook in-app browser', function (t) {
-  assertAgentString(t,
+test('detects facebook in-app browser', function(t) {
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_5 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D60 [FBAN/FBIOS;FBAV/157.0.0.42.96;FBBV/90008621;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/11.2.5;FBSS/2;FBCR/Verizon;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]',
     { name: 'facebook', version: '157.0.0', os: 'iOS' }
   );
@@ -223,8 +253,9 @@ test('detects facebook in-app browser', function (t) {
   t.end();
 });
 
-test('detects instagram in-app browser', function (t) {
-  assertAgentString(t,
+test('detects instagram in-app browser', function(t) {
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69 Instagram 8.4.0 (iPhone7,2; iPhone OS 9_3_2; nb_NO; nb-NO; scale=2.00; 750x1334',
     { name: 'instagram', version: '8.4.0', os: 'iOS' }
   );
@@ -232,23 +263,27 @@ test('detects instagram in-app browser', function (t) {
   t.end();
 });
 
-test('detects native iOS WebView browser', function (t) {
-  assertAgentString(t,
+test('detects native iOS WebView browser', function(t) {
+  assertAgentString(
+    t,
     'User-Agent: Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile',
     { name: 'ios-webview', version: '533.17.9', os: 'iOS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E216',
     { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B92',
     { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (iPhone; CPU iPhone OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko)',
     { name: 'ios-webview', version: '605.1.15', os: 'iOS' }
   );
@@ -257,7 +292,8 @@ test('detects native iOS WebView browser', function (t) {
 });
 
 test('detects Samsung Internet browser', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-G925F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36',
     { name: 'samsung', version: '4.0.0', os: 'Android OS' }
   );
@@ -265,8 +301,9 @@ test('detects Samsung Internet browser', function(t) {
   t.end();
 });
 
-test('detects crawler: AhrefsBot', function (t) {
-  assertAgentString(t,
+test('detects crawler: AhrefsBot', function(t) {
+  assertAgentString(
+    t,
     'Mozilla/5.0 (compatible; AhrefsBot/5.2; +http://ahrefs.com/robot/)',
     { bot: true, name: 'bot', version: null, os: null }
   );
@@ -274,8 +311,9 @@ test('detects crawler: AhrefsBot', function (t) {
   t.end();
 });
 
-test('detects crawler: GoogleBot', function (t) {
-  assertAgentString(t,
+test('detects crawler: GoogleBot', function(t) {
+  assertAgentString(
+    t,
     'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36',
     { bot: true, name: 'bot', version: null, os: null }
   );
@@ -283,8 +321,9 @@ test('detects crawler: GoogleBot', function (t) {
   t.end();
 });
 
-test('detects crawler: YandexBot', function (t) {
-  assertAgentString(t,
+test('detects crawler: YandexBot', function(t) {
+  assertAgentString(
+    t,
     'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
     { bot: true, name: 'bot', version: null, os: null }
   );
@@ -292,31 +331,36 @@ test('detects crawler: YandexBot', function (t) {
   t.end();
 });
 
-test('detects Opera-Mini', function (t) {
-  assertAgentString(t,
+test('detects Opera-Mini', function(t) {
+  assertAgentString(
+    t,
     'Opera/9.80 (Android; Opera Mini/8.0.1807/36.1609; U; en) Presto/2.12.423 Version/12.16',
     { name: 'opera-mini', version: '12.16.0', os: 'Android OS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Opera/9.80 (BlackBerry; Opera Mini/6.5.27548/27.2020; U; en) Presto/2.8.119 Version/11.10',
     { name: 'opera-mini', version: '11.10.0', os: 'BlackBerry OS' }
   );
   t.end();
 });
 
-test('detects Silk', function (t) {
-  assertAgentString(t,
+test('detects Silk', function(t) {
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Linux; Android 4.4.3; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Safari/537.36',
     { name: 'silk', version: '44.1.54', os: 'Android OS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Safari/537.36',
     { name: 'silk', version: '44.1.54', os: 'Linux' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Linux; U; Android 4.4.3; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/44.1.54 like Chrome/44.0.2403.63 Mobile Safari/537.36',
     { name: 'silk', version: '44.1.54', os: 'Android OS' }
   );
@@ -324,13 +368,15 @@ test('detects Silk', function (t) {
   t.end();
 });
 
-test('detects Chrome OS', function (t) {
-  assertAgentString(t,
+test('detects Chrome OS', function(t) {
+  assertAgentString(
+    t,
     'Mozilla/5.0 (X11; CrOS x86_64 10895.78.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.120 Safari/537.36',
     { name: 'chrome', version: '69.0.3497', os: 'Chrome OS' }
   );
 
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Gecko/20100101 Firefox/29.0',
     { name: 'firefox', version: '29.0.0', os: 'Chrome OS' }
   );
@@ -338,7 +384,8 @@ test('detects Chrome OS', function (t) {
 });
 
 test('detects miui', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Linux; U; Android 7.0; en-us; MI 5 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.146 Mobile Safari/537.36 XiaoMi/MiuiBrowser/9.0.3',
     { name: 'miui', version: '9.0.3', os: 'Android OS' }
   );
@@ -346,7 +393,8 @@ test('detects miui', function(t) {
 });
 
 test('detects Beaker Browser', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) BeakerBrowser/0.8.7 Chrome/69.0.3497.128 Electron/4.1.3 Safari/537.36',
     { name: 'beaker', version: '0.8.7', os: 'Windows 10' }
   );
@@ -354,7 +402,8 @@ test('detects Beaker Browser', function(t) {
 });
 
 test('detects edge chromium', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24',
     { name: 'edge-chromium', version: '74.1.96', os: 'Windows 10' }
   );
@@ -362,18 +411,15 @@ test('detects edge chromium', function(t) {
 });
 
 test('handles no browser', function(t) {
-    assertAgentString(t,
-        null,
-        null
-    );
+  assertAgentString(t, null, null);
 
-    t.end();
+  t.end();
 });
-
 
 /* https://developer.chrome.com/multidevice/user-agent */
 test('detects Chromium-based WebView On Android', function(t) {
-  assertAgentString(t,
+  assertAgentString(
+    t,
     'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36',
     { name: 'chromium-webview', version: '43.0.2357', os: 'Android OS' }
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,6 +354,11 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 r2@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/r2/-/r2-2.0.1.tgz#94cd802ecfce9a622549c8182032d8e4a2b2e612"


### PR DESCRIPTION
This commit brings the source file formatting inline with what `prettier` would choose, so future PRs won't introduce whitespace noise.

Note the addition of the manual `yarn autoformat` command also which manually runs `prettier` against the `src` and `test` directories.