### PR TITLE
implementation of a new result type: SearchBotDeviceInfo

### DIFF
--- a/test/logic.js
+++ b/test/logic.js
@@ -434,3 +434,18 @@ test('detects Chromium-based WebView On Android', function(t) {
   );
   t.end();
 });
+
+test('detects extended bot info', function(t) {
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    {
+      name: 'chrome',
+      version: '41.0.2272',
+      os: 'Android OS',
+      bot: 'Googlebot',
+    },
+  );
+
+  t.end();
+});


### PR DESCRIPTION
A potential implementation that addresses the request in #126 

From an implementation perspective I've implemented a result class - `SearchBotDeviceInfo` which adds the `bot` string so that the result of the detection of the UA:

```
Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
```

is:

```
{
  name: 'chrome',
  version: '41.0.2272',
  os: 'Android OS',
  bot: 'Googlebot',
}
```

In terms of being able to determine that we have captured one of these new types of results, either the `bot` attribute can be tested, e.g. `typeof result.bot == 'string'` or using the `instanceof` check given the result is a class.  Using a truthy check on the bot attribute will also pickup those instances of standard search bots that aren't simulating devices also.

This is starting to increase the complexity of the result type, and I'm not really one for doing `instanceof` checks so I think it might be time to add a `kind` [discriminator](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions) also.

I'd be keen to bump major on this too if we decide this is a good way to go.

