### PR TITLE
Add "node" to Browser TypeScript type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export type Browser =
   | 'fxios'
   | 'opera-mini'
   | 'opera'
+  | 'node'
   | 'ie'
   | 'bb10'
   | 'android'


### PR DESCRIPTION
Fixes 
<img width="765" alt="Screen Shot 2020-02-10 at 11 01 59 AM" src="https://user-images.githubusercontent.com/3408480/74166638-e7b93700-4bf4-11ea-845c-d98faa01a929.png">

## More Explanation

When calculating browser info on the server-side (we're using NextJS), the browser's name is `node`. Unfortunately, that's not included in the types, so for now, we are doing a type-cast to `any`.