### PR TITLE
ADD: cache parseUserAgent result to increase performance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ export function detect(
   userAgent?: string,
 ): BrowserInfo | SearchBotDeviceInfo | BotInfo | NodeInfo | ReactNativeInfo | null {
   if (!!userAgent) {
-    return parseUserAgent(userAgent);
+    return cachedParseUserAgent(userAgent);
   }
 
   if (
@@ -202,7 +202,7 @@ export function detect(
   }
 
   if (typeof navigator !== 'undefined') {
-    return parseUserAgent(navigator.userAgent);
+    return cachedParseUserAgent(navigator.userAgent);
   }
 
   return getNodeVersion();
@@ -294,4 +294,12 @@ function createVersionParts(count: number): string[] {
   }
 
   return output;
+}
+
+const parseCache: { [key:string]: BrowserInfo | SearchBotDeviceInfo | BotInfo | null } = {};
+
+export function cachedParseUserAgent(
+  ua: string,
+): BrowserInfo | SearchBotDeviceInfo | BotInfo | null {
+  return parseCache[ua] || (parseCache[ua] = parseUserAgent(ua));
 }

--- a/test/logic.js
+++ b/test/logic.js
@@ -24,6 +24,12 @@ test('detects Chrome', function(t) {
     { type: 'browser', name: 'chrome', version: '72.0.3626', os: 'Windows 10' },
   );
 
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 Safari/537.36',
+    { type: 'browser', name: 'chrome', version: '72.0.3626', os: 'Windows 10' },
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
Many users of the library might be calling the detect function directly in React render functions or other pieces of code that gets rerun many times. Since usually the browser running the detect function will not change it's user agent, it's worth it to save the already parsed userAgents to avoid parsing the same one multiple times.