### PR TITLE
Added Windows CE/Pocket Internet Explorer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ export type Browser =
   | 'fxios'
   | 'opera-mini'
   | 'opera'
+  | 'pie'
   | 'ie'
   | 'bb10'
   | 'android'
@@ -105,6 +106,7 @@ export type OperatingSystem =
   | 'Windows 8.1'
   | 'Windows 10'
   | 'Windows ME'
+  | 'Windows CE'
   | 'Open BSD'
   | 'Sun OS'
   | 'Linux'
@@ -145,6 +147,8 @@ const userAgentRules: UserAgentRule[] = [
   ['opera-mini', /Opera Mini.*Version\/([0-9\.]+)/],
   ['opera', /Opera\/([0-9\.]+)(?:\s|$)/],
   ['opera', /OPR\/([0-9\.]+)(:?\s|$)/],
+  ['pie',/^Microsoft Pocket Internet Explorer\/(\d+\.\d+)$/],
+  ['pie',/^Mozilla\/\d\.\d\s\(compatible\/\s(?:MSP?IE|MSInternet Explorer) (\d+\.\d+)\/.*Windows CE.*\)$/],
   ['ie', /Trident\/7\.0.*rv\:([0-9\.]+).*\).*Gecko$/],
   ['ie', /MSIE\s([0-9\.]+);.*Trident\/[4-7].0/],
   ['ie', /MSIE\s(7\.0)/],
@@ -176,6 +180,7 @@ const operatingSystemRules: OperatingSystemRule[] = [
   ['Windows 8.1', /(Windows NT 6.3)/],
   ['Windows 10', /(Windows NT 10.0)/],
   ['Windows ME', /Windows ME/],
+  ['Windows CE', /Windows CE|WinCE/],
   ['Open BSD', /OpenBSD/],
   ['Sun OS', /SunOS/],
   ['Chrome OS', /CrOS/],


### PR DESCRIPTION
Support for user agent strings for various Windows CE devices running Pocket Internet Explorer / Internet Explorer Mobile

Examples:

Microsoft Pocket Internet Explorer/0.6
Mozilla/1.1 (compatible/ MSPIE 1.1/ Windows CE)
Mozilla/1.1 (compatible/ MSPIE 2.0/ Windows CE)
Mozilla/2.0 (compatible/ MSIE 3.02/ Windows CE)
Mozilla/4.0 (compatible/ MSIE 4.01/ Windows CE)
Mozilla/4.0 (compatible/ MSIE 4.01/ Windows NT Windows CE)
Mozilla/4.0 (compatible/ MSIE 4.01/ Windows NT Windows CE/ 800x480)
Mozilla/4.0 (compatible/ MSIE 5.5/ Windows CE)
Mozilla/4.0 (compatible/ MSIE 6.0/ Windows CE)
Mozilla/2.0 (compatible/ MSInternet Explorer 3.02/ Windows CE/ 240x320)
Mozilla/2.0 (compatible/ MSIE 3.02/ Windows CE/ 240x320)
Mozilla/2.0 (compatible/ MSIE 3.02/ Windows CE/ PPC/ javascript/ 240x320)
Mozilla/2.0 (compatible/ MSIE 3.02/ Windows CE/ PPC/ 240x320)
Mozilla/4.0 (compatible/ MSIE 4.01/ Windows CE/ PPC/ 240x320)
Mozilla/2.0 (compatible/ MSIE 3.02/ Windows CE/ Smartphone/ javascript/ *)
Mozilla/2.0 (compatible/ MSIE 3.02/ Windows CE/ Smartphone/ 176x220)
Mozilla/2.0 (compatible/ MSIE 3.02/ Windows CE/ Smartphone/ *)
Mozilla/4.0 (compatible/ MSIE 4.01/ Windows CE/ Smartphone/ 176x220/ SPV C500/ OpVer 4.1.1.0)
Mozilla/4.0 (compatible/ MSIE 4.01/ Windows CE/ Smartphone/ 176x220/ SPV C500/ OpVer 4.1.3.0)