### PR TITLE
Allow chrome to add a variation string as a suffix of the version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ const userAgentRules: UserAgentRule[] = [
     'chromium-webview',
     /(?!Chrom.*OPR)wv\).*Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/,
   ],
-  ['chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(:?\s|$)/],
+  ['chrome', /(?!Chrom.*OPR)Chrom(?:e|ium)\/([0-9\.]+)(\.[a-zA-Z0-9]+)?(:?\s|$)/],
   ['phantomjs', /PhantomJS\/([0-9\.]+)(:?\s|$)/],
   ['crios', /CriOS\/([0-9\.]+)(:?\s|$)/],
   ['firefox', /Firefox\/([0-9\.]+)(?:\s|$)/],

--- a/test/logic.js
+++ b/test/logic.js
@@ -24,6 +24,18 @@ test('detects Chrome', function(t) {
     { type: 'browser', name: 'chrome', version: '72.0.3626', os: 'Windows 10' },
   );
 
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.0 Safari/537.36',
+    { type: 'browser', name: 'chrome', version: '83.0.4103', os: 'Linux' },
+  );
+
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.0.sitesfixer Safari/537.36',
+    { type: 'browser', name: 'chrome', version: '83.0.4103', os: 'Linux' },
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
We're stumbled on the user agent showed in the test in our logs, detect-browser returned null instead of parsing it.
This change allows detect-browser to accept and parse this user agent