### PR TITLE
Facebook browser on iOS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ const userAgentRules: UserAgentRule[] = [
   ['android', /Android\s([0-9\.]+)/],
   ['ios', /Version\/([0-9\._]+).*Mobile.*Safari.*/],
   ['safari', /Version\/([0-9\._]+).*Safari/],
-  ['facebook', /FBAV\/([0-9\.]+)/],
+  ['facebook', /FB[AS]V\/([0-9\.]+)/],
   ['instagram', /Instagram\s([0-9\.]+)/],
   ['ios-webview', /AppleWebKit\/([0-9\.]+).*Mobile/],
   ['ios-webview', /AppleWebKit\/([0-9\.]+).*Gecko\)$/],


### PR DESCRIPTION
Current Facebook browser regex doesn't seem to correctly handle iOS case:

Sample user agents:

Android Facebook browser:
`Mozilla/5.0 (Linux; Android 10; ONEPLUS A6000 Build/QKQ1.190716.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/93.0.4577.82 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/335.0.0.28.118;]`

iOS Facebook browser:
`Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_1 like Mac OS X) WebKit/8610 (KHTML, like Gecko) Mobile/18D61 [FBAN/FBIOS;FBDV/iPhone8,4;FBMD/iPhone;FBSN/iOS;FBSV/14.4.1;FBSS/2;FBID/phone;FBLC/ru_RU;FBOP/5]`

Not sure which part of the iOS string is the version, please correct me if I made a wrong call with `FBSV/14.4.1`.