### PR TITLE
Fix #123 import node types for build only

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,1 @@
+import 'node';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "./",
     "rootDir": "./src/",
     "strict": true,
-    "types": ["node"]
+    "types": []
   },
   "include": [
     "./src/**/*.ts"


### PR DESCRIPTION
Use `import` in a `d.ts` file to reference `node` types, so that it is included only during build.