### PR TITLE
fix: add non-null version to ReactNativeInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export class ReactNativeInfo
   implements DetectedInfo<'react-native', 'react-native', null, null> {
   public readonly type = 'react-native';
   public readonly name: 'react-native' = 'react-native';
-  public readonly version: null = null;
+  public readonly version: string = '1000.0.0'; // See react-native/package.json
   public readonly os: null = null;
 }
 


### PR DESCRIPTION
While implementing with amazon-chime-sdk-js, the react-native browser detection caused an error documented in this issue: https://github.com/aws/amazon-chime-sdk-js/issues/1856. This PR adds a default version based on the version here, which gets replaced when they cut a new version

https://github.com/facebook/react-native/blob/09b69036c023ccab47b7c5b950247217bb975686/package.json#L4


