### PR TITLE
Add Haiku to OS detection logic.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,7 @@ export type OperatingSystem =
   | 'Windows CE'
   | 'Open BSD'
   | 'Sun OS'
+  | 'Haiku'
   | 'Linux'
   | 'Mac OS'
   | 'QNX'
@@ -193,6 +194,7 @@ const operatingSystemRules: OperatingSystemRule[] = [
   ['Open BSD', /OpenBSD/],
   ['Sun OS', /SunOS/],
   ['Chrome OS', /CrOS/],
+  ['Haiku', /Haiku/],
   ['Linux', /(Linux)|(X11)/],
   ['Mac OS', /(Mac_PowerPC)|(Macintosh)/],
   ['QNX', /QNX/],

--- a/test/logic.js
+++ b/test/logic.js
@@ -550,3 +550,28 @@ test('detects extended bot info', function(t) {
 
   t.end();
 });
+
+test('detects Haiku', function(t) {
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (Macintosh; Intel Haiku R1) AppleWebKit/605.1.15 (KHTML, like Gecko) WebPositive/1.3 Version/14.1.2 Safari/605.1.15',
+    {
+      type: 'browser',
+      name: 'safari',
+      version: '14.1.2',
+      os: 'Haiku',
+    },
+  );
+  assertAgentString(
+    t,
+    'Mozilla/5.0 (X11; Haiku x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Falkon/23.08.4 QtWebEngine/5.15.17 Chrome/87.0.4280.144 Safari/537.36',
+    {
+      type: 'browser',
+      name: 'chrome',
+      version: '87.0.4280',
+      os: 'Haiku',
+    },
+  );
+
+  t.end();
+});


### PR DESCRIPTION
It must go before Linux because otherwise the "X11" check will misdetect Linux here.

Right now, Haiku's native WebKit is detected as Safari since that's what the user-agent most specifically contains. It would probably make more sense to list the AppleWebKit version (the WebPositive/ version has not changed in years.) But at least we get the OS correct now.